### PR TITLE
async image loading task (sometimes) won't proceed when the task has been cancelled immediately

### DIFF
--- a/Sources/Nuke/Pipeline/ImagePipeline.swift
+++ b/Sources/Nuke/Pipeline/ImagePipeline.swift
@@ -461,7 +461,10 @@ public final class ImagePipeline: @unchecked Sendable {
     }
 
     private func cancel(_ task: ImageTask) {
-        guard let subscription = tasks.removeValue(forKey: task) else { return }
+        guard let subscription = tasks.removeValue(forKey: task) else {
+            task.onCancel?()
+            return
+        }
         dispatchCallback(to: task.callbackQueue) {
             if !task.isDataTask {
                 self.delegate.imageTaskDidCancel(task)


### PR DESCRIPTION
## What happened

In my application, I found an issue that won't release resources captured by a task including image loading processing.
From a deep-dive investigation, I noticed something seems to be happening race-condition-ish inside ImagePipeline.

I described what's happening inside in the attached screenshot.

The below code is one of the cases that causes this case potentially.

```swift
let loadingTask = Task {
  let imageResponse = try await ImagePipeline.shared.image(for: request, delegate: nil)
  ...
  // there are some captured resources
  ...
}

...

loadingTask.cancel()
```

![CleanShot 2023-02-15 at 01 33 03@2x](https://user-images.githubusercontent.com/1888355/218799325-0a3ece94-5677-466a-9641-375c4fd504cb.png)

![CleanShot 2023-02-15 at 01 34 14@2x](https://user-images.githubusercontent.com/1888355/218799964-bcb973ed-e3e0-4b94-a9f6-d7b45c99c9a2.png)


## Solution

I could fix this issue by adding a few lines of code that trigger cancel for the continuation even if the task is not found by the dictionary.
However, I'm not confident with this update. I guess should be added something more operations like handling delegates we could see in the original place. 
Or we should think about adding the task with mutex.

What do you think?
Thanks. I appreciate your great work.

